### PR TITLE
bugfix: socache options is recognized in wrong way

### DIFF
--- a/mod_barrier.c
+++ b/mod_barrier.c
@@ -376,7 +376,7 @@ static const char *barrier_init_cache(cmd_parms *cmd, void *cfg, const char *arg
 	}
 
 	// create instance
-	socache_provider->create(&socache_instance, separator, cmd->temp_pool, cmd->pool);
+	socache_provider->create(&socache_instance, separator + 1, cmd->temp_pool, cmd->pool);
 
 	return errmsg;
 }


### PR DESCRIPTION
BarrierSOCache option is parsed in wrong way and passed incorrect socache options to shared object cache providers.
